### PR TITLE
Add shared memory circular buffer

### DIFF
--- a/src/cvkitworker/utils/__init__.py
+++ b/src/cvkitworker/utils/__init__.py
@@ -3,7 +3,7 @@ Utility modules for cvkitworker.
 """
 
 from .timing import (
-    measure_timing, 
+    measure_timing,
     measure_face_detection,
     measure_image_processing,
     measure_frame_processing,
@@ -11,6 +11,7 @@ from .timing import (
     measure_scaling,
     get_timing_manager
 )
+from .shared_buffer import SharedMemoryCircularBuffer
 
 __all__ = [
     'measure_timing',
@@ -19,5 +20,6 @@ __all__ = [
     'measure_frame_processing',
     'measure_color_conversion',
     'measure_scaling',
-    'get_timing_manager'
+    'get_timing_manager',
+    'SharedMemoryCircularBuffer'
 ]

--- a/src/cvkitworker/utils/shared_buffer.py
+++ b/src/cvkitworker/utils/shared_buffer.py
@@ -1,0 +1,76 @@
+import numpy as np
+from multiprocessing import shared_memory
+from typing import List, Optional
+
+class SharedMemoryCircularBuffer:
+    """Circular buffer backed by :class:`multiprocessing.shared_memory.SharedMemory`."""
+
+    def __init__(
+        self,
+        frame_shape: tuple,
+        dtype: np.dtype,
+        capacity: int,
+        name: Optional[str] = None,
+        create: bool = True,
+    ):
+        self.frame_shape = tuple(frame_shape)
+        self.dtype = np.dtype(dtype)
+        self.capacity = int(capacity)
+        self.frame_size = int(np.prod(self.frame_shape)) * self.dtype.itemsize
+        self.total_size = self.frame_size * self.capacity
+
+        if create:
+            self.shm = shared_memory.SharedMemory(create=True, size=self.total_size, name=name)
+            self.owns_shm = True
+        else:
+            if name is None:
+                raise ValueError("Must specify name when create=False")
+            self.shm = shared_memory.SharedMemory(name=name)
+            self.owns_shm = False
+
+        self.buffer = np.ndarray(
+            (self.capacity,) + self.frame_shape,
+            dtype=self.dtype,
+            buffer=self.shm.buf,
+        )
+
+        self.index = 0
+        self.length = 0
+
+    @property
+    def name(self) -> str:
+        """Return the shared memory block name."""
+        return self.shm.name
+
+    def append(self, frame: np.ndarray) -> None:
+        """Append a frame to the buffer, overwriting the oldest if full."""
+        if frame.shape != self.frame_shape or frame.dtype != self.dtype:
+            raise ValueError("Frame has incompatible shape or dtype")
+        np.copyto(self.buffer[self.index], frame)
+        self.index = (self.index + 1) % self.capacity
+        if self.length < self.capacity:
+            self.length += 1
+
+    def get_last(self) -> np.ndarray:
+        """Return a copy of the most recently added frame."""
+        if self.length == 0:
+            raise IndexError("Buffer is empty")
+        idx = (self.index - 1) % self.capacity
+        return self.buffer[idx].copy()
+
+    def get_all(self) -> List[np.ndarray]:
+        """Return copies of all frames in the buffer in insertion order."""
+        if self.length == 0:
+            return []
+        frames = []
+        start = (self.index - self.length) % self.capacity
+        for i in range(self.length):
+            idx = (start + i) % self.capacity
+            frames.append(self.buffer[idx].copy())
+        return frames
+
+    def close(self) -> None:
+        """Close and unlink shared memory if owned."""
+        self.shm.close()
+        if self.owns_shm:
+            self.shm.unlink()

--- a/tests/test_shared_memory_buffer.py
+++ b/tests/test_shared_memory_buffer.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+# Ensure project src is on path
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+from cvkitworker.utils.shared_buffer import SharedMemoryCircularBuffer
+
+
+class TestSharedMemoryCircularBuffer:
+    def test_append_and_get_last(self):
+        buf = SharedMemoryCircularBuffer(frame_shape=(2, 2, 3), dtype=np.uint8, capacity=2)
+        f1 = np.ones((2, 2, 3), dtype=np.uint8)
+        f2 = np.ones((2, 2, 3), dtype=np.uint8) * 2
+        buf.append(f1)
+        assert np.array_equal(buf.get_last(), f1)
+        buf.append(f2)
+        assert np.array_equal(buf.get_last(), f2)
+        buf.close()
+
+    def test_overwrite_and_get_all(self):
+        buf = SharedMemoryCircularBuffer(frame_shape=(1, 1, 1), dtype=np.uint8, capacity=3)
+        for i in range(5):
+            buf.append(np.full((1, 1, 1), i, dtype=np.uint8))
+        frames = buf.get_all()
+        expected = [np.array([[[2]]], dtype=np.uint8),
+                    np.array([[[3]]], dtype=np.uint8),
+                    np.array([[[4]]], dtype=np.uint8)]
+        assert len(frames) == 3
+        for a, e in zip(frames, expected):
+            assert np.array_equal(a, e)
+        buf.close()


### PR DESCRIPTION
## Summary
- implement `SharedMemoryCircularBuffer` for frame storage
- expose buffer class in utils package
- test circular buffer functionality

## Testing
- `pytest tests/test_shared_memory_buffer.py -q`
- `pytest -q` *(fails: FileNotFoundError for video files, AttributeError for _resize_frame)*

------
https://chatgpt.com/codex/tasks/task_e_684bb63838d08322bd049b9f5dba0668